### PR TITLE
Fix pagination on all pages

### DIFF
--- a/src/containers/TopAsks/index.js
+++ b/src/containers/TopAsks/index.js
@@ -14,7 +14,13 @@ class TopAsks extends PureComponent {
   }
 
   render() {
-    const { ids, items, isLoading, isLoadingMore } = this.props;
+    const {
+      ids,
+      items,
+      isLoading,
+      isLoadingMore,
+      getTopAskItemsRequest
+    } = this.props;
 
     return (
       <AppLayout>

--- a/src/containers/TopShows/index.js
+++ b/src/containers/TopShows/index.js
@@ -10,7 +10,13 @@ class TopShows extends React.PureComponent {
   }
 
   render() {
-    const { ids, isLoading, items, isLoadingMore } = this.props;
+    const {
+      ids,
+      isLoading,
+      items,
+      isLoadingMore,
+      getTopShowItemsRequest
+    } = this.props;
 
     return (
       <AppLayout>

--- a/src/containers/TopStories/index.js
+++ b/src/containers/TopStories/index.js
@@ -14,7 +14,13 @@ class TopStories extends PureComponent {
   }
 
   render() {
-    const { isLoading, isLoadingMore, ids, items } = this.props;
+    const {
+      isLoading,
+      isLoadingMore,
+      ids,
+      items,
+      getTopStoryItemsRequest
+    } = this.props;
 
     return (
       <AppLayout>


### PR DESCRIPTION
**What does this PR do?**
This PR fixes the pagination functionality on all the pages (topStories, topAsks, topShows)

**Description of Task to be completed?**
Fix the pagination functionality on topStories, topAsks and topShows page.

**How should this be manually tested?**
- Run git fetch
- Run git checkout fx-pagination-functionality
- Install the dependencies via yarn install
- Start the server with yarn start
- Navigate to all the links and test for the pagination

**Screenshots (if appropriate)**
TopStories
![2019-09-12 16 45 22](https://user-images.githubusercontent.com/41106626/64789322-d94eec80-d57c-11e9-8cdb-18291b7bbc82.gif)

TopAsks
![2019-09-12 16 46 33](https://user-images.githubusercontent.com/41106626/64789398-f4b9f780-d57c-11e9-8a38-543f098b5155.gif)

TopShows
![2019-09-12 16 47 38](https://user-images.githubusercontent.com/41106626/64789467-17e4a700-d57d-11e9-994e-83f8a84191ff.gif)
